### PR TITLE
chore: add tests for common utils

### DIFF
--- a/playground/chore_add-tests-for-common-utils/verify_tests.py
+++ b/playground/chore_add-tests-for-common-utils/verify_tests.py
@@ -1,0 +1,18 @@
+import subprocess
+import sys
+
+
+def main():
+    print("Running tests with pytest...", flush=True)
+    try:
+        subprocess.check_call(
+            [sys.executable, "-m", "pytest", "-q"]
+        )  # exit code assertion
+        print("All tests passed.")
+    except subprocess.CalledProcessError as e:
+        print(f"Tests failed with exit code {e.returncode}")
+        sys.exit(e.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -13,7 +13,7 @@ from abc import ABCMeta, abstractmethod
 #     tabulate(dic, headers="keys", tablefmt="psql")
 # )  # print with fancy 'psql' format
 vars_ = lambda obj: {k: v for k, v in vars(obj).items() if not k.startswith("__")}
-str2dt = lambda s, format="%Y-%m-%d": datetime.datetime.strptime(s, format)
+str2dt = lambda s, format="%Y-%m-%d": datetime.strptime(s, format)
 dt2str = lambda dt, format="%Y-%m-%d": dt.strftime(format)
 
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,2 @@
 pytest==8.3.2
+pytest-asyncio==0.23.8

--- a/tests/test_depth_logging.py
+++ b/tests/test_depth_logging.py
@@ -1,0 +1,20 @@
+from src.common.depth_logging import D
+
+
+def test_depth_decorator_nested_calls():
+    calls = []
+
+    @D
+    def inner(x):
+        calls.append(f"inner-{x}")
+        return x + 1
+
+    @D
+    def outer(y):
+        z = inner(y)
+        calls.append(f"outer-{z}")
+        return z * 2
+
+    result = outer(3)
+    assert result == 8
+    assert calls == ["inner-3", "outer-4"]

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from src.common.loader import ls_all, ls_dir, ls_file
+
+
+def test_ls_functions_with_tmp_path(tmp_path):
+    # Create directories and files
+    d1 = tmp_path / "dir1"
+    d2 = tmp_path / "dir2"
+    f1 = tmp_path / "file1.txt"
+    f2 = tmp_path / "file2.txt"
+    d1.mkdir()
+    d2.mkdir()
+    f1.write_text("a")
+    f2.write_text("b")
+
+    all_items = ls_all(str(tmp_path))
+    dir_items = ls_dir(str(tmp_path))
+    file_items = ls_file(str(tmp_path))
+
+    # Ensure sorted and correct contents
+    assert all_items == sorted([str(p) for p in [d1, d2, f1, f2]])
+    assert dir_items == sorted([str(d1), str(d2)])
+    assert file_items == sorted([str(f1), str(f2)])

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,45 @@
+import logging
+
+import pytest
+
+from src.common import logger as logger_module
+from src.common.logger import build_general_logger, pretty_dict, STYLES
+
+
+@pytest.fixture()
+def silent_logger():
+    lg = build_general_logger(
+        logger_name="test_logger", log_to_console=False, log_to_file=False
+    )
+    return lg
+
+
+def test_build_general_logger_basic():
+    lg = build_general_logger(
+        logger_name="test_logger_basic", log_to_console=False, log_to_file=False
+    )
+    assert isinstance(lg, logging.Logger)
+
+
+def test_pretty_dict_formats_dict():
+    d = {"a": 1, "b": {"c": 2}}
+    s = pretty_dict(d)
+    assert "\n" in s and '"a"' in s and '"c"' in s
+
+
+def test_slog_and_log_helpers(monkeypatch, silent_logger):
+    # Redirect module-level logger to silent logger to avoid I/O
+    monkeypatch.setattr(logger_module, "logger", silent_logger, raising=True)
+
+    msg = {"msg": "hello"}
+    out = logger_module.slog(msg, style="OKGREEN")
+    assert STYLES["BOLD"] in out and "hello" in out
+
+    info_out = logger_module.log_info("test", prefix="TAG")
+    assert "[TAG]" in info_out
+
+    warn_out = logger_module.log_warning("warn")
+    assert "warn" in warn_out
+
+    err_out = logger_module.log_error("err")
+    assert "err" in err_out

--- a/tests/test_request_utils.py
+++ b/tests/test_request_utils.py
@@ -1,0 +1,89 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+import requests
+
+from src.common.request_utils import safe_request, async_safe_request
+
+
+class DummyAsyncResponse:
+    def __init__(self, payload: dict, raise_error: Exception | None = None):
+        self._payload = payload
+        self._raise_error = raise_error
+
+    async def __aenter__(self):
+        if self._raise_error:
+            raise self._raise_error
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self):
+        if self._raise_error:
+            raise self._raise_error
+
+    async def json(self):
+        return self._payload
+
+
+class DummySession:
+    def __init__(self, payload: dict, raise_error: Exception | None = None):
+        self._payload = payload
+        self._raise_error = raise_error
+
+    def request(self, method, url, json=None, headers=None, **kwargs):
+        return DummyAsyncResponse(self._payload, self._raise_error)
+
+
+def test_safe_request_returns_full_json_when_return_data_false():
+    fake = {"success": True, "data": {"x": 1}, "message": "ok"}
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status.return_value = None
+    mock_resp.json.return_value = fake
+
+    with patch.object(requests, "request", return_value=mock_resp) as m:
+        out = safe_request("http://example.com", method="get", return_data=False)
+    assert out == fake
+
+
+def test_safe_request_returns_data_when_return_data_true():
+    fake = {"success": True, "data": {"x": 1}, "message": "ok"}
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status.return_value = None
+    mock_resp.json.return_value = fake
+
+    with patch.object(requests, "request", return_value=mock_resp):
+        out = safe_request("http://example.com", method="get", return_data=True)
+    assert out == {"x": 1}
+
+
+def test_safe_request_raises_on_error():
+    with patch.object(requests, "request", side_effect=requests.HTTPError("bad")):
+        with pytest.raises(Exception):
+            safe_request("http://example.com", method="get")
+
+
+@pytest.mark.asyncio
+async def test_async_safe_request_returns_full_json_when_return_data_false():
+    payload = {"success": True, "data": {"y": 2}, "message": "ok"}
+    session = DummySession(payload)
+    out = await async_safe_request(session, "http://example.com", method="get")
+    assert out == payload
+
+
+@pytest.mark.asyncio
+async def test_async_safe_request_returns_data_when_return_data_true():
+    payload = {"success": True, "data": {"y": 2}, "message": "ok"}
+    session = DummySession(payload)
+    out = await async_safe_request(
+        session, "http://example.com", method="get", return_data=True
+    )
+    assert out == {"y": 2}
+
+
+@pytest.mark.asyncio
+async def test_async_safe_request_raises_on_error():
+    session = DummySession({}, raise_error=requests.HTTPError("bad"))
+    with pytest.raises(Exception):
+        await async_safe_request(session, "http://example.com", method="get")

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -1,0 +1,17 @@
+from time import sleep
+
+from src.common.timer import Timer, T
+
+
+def test_timer_context_runs_without_error():
+    with Timer("Test Block") as t:
+        assert t.name == "Test Block"
+        sleep(0.01)
+
+
+def test_timer_decorator_returns_function_result():
+    @T
+    def add(a, b):
+        return a + b
+
+    assert add(2, 3) == 5

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,56 @@
+import pytest
+from datetime import datetime
+
+from src.common.utils import str2bool, str2dt, dt2str, vars_, SingletonBase
+
+
+def test_str2bool_true_cases():
+    for v in ["yes", "true", "t", "y", "1", True, "YeS", "TrUe"]:
+        assert str2bool(v) is True
+
+
+def test_str2bool_false_cases():
+    for v in ["no", "false", "f", "n", "0", False, "FaLsE"]:
+        assert str2bool(v) is False
+
+
+def test_str2bool_invalid():
+    with pytest.raises(ValueError):
+        str2bool("maybe")
+
+
+def test_dt_str_conversion():
+    s = "2024-01-31"
+    dt = str2dt(s)
+    assert isinstance(dt, datetime)
+    assert dt2str(dt) == s
+
+
+def test_vars_filters_dunder():
+    class Obj:
+        def __init__(self):
+            self.a = 1
+            self.__hidden = 2
+
+    v = vars_(Obj())
+    # Current behavior keeps name-mangled privates (not starting with '__')
+    assert v["a"] == 1
+    assert v["_Obj__hidden"] == 2
+
+
+def test_singleton_base_instance_key():
+    class Dummy(SingletonBase):
+        @classmethod
+        def _generate_instance_key(cls, key: str) -> tuple:
+            return (key,)
+
+        def _init_once(self, key: str) -> None:
+            self.key = key
+
+    a1 = Dummy("x")
+    a2 = Dummy("x")
+    b = Dummy("y")
+
+    assert a1 is a2
+    assert a1 is not b
+    assert a1.key == "x" and b.key == "y"


### PR DESCRIPTION
### Issues
- Fixes #

### Descriptions
1. 공통 유틸리티 모듈(`src/common/*.py`)에 대한 테스트 케이스를 추가하여 회귀 방지 및 동작 보장을 강화했습니다.
2. `pytest` 구성(`pyproject.toml`)을 정비하고 테스트 의존성(`tests/requirements.txt`)을 명시했습니다.
3. README 업데이트: Quickstart, 올바른 import 예제(Timer/Depth logging/Logger), HTTP 요청 동기/비동기 예시 추가.

### Tests
- playground/chore_add-tests-for-common-utils/verify_tests.py: 모든 테스트가 통과함을 간단히 확인할 수 있는 실행 스크립트입니다.
- 로컬에서 `pytest -q` 결과: 19 passed.